### PR TITLE
added e17 profile conflict to moksha desktop

### DIFF
--- a/bodhi-desktop-moksha/DEBIAN/control
+++ b/bodhi-desktop-moksha/DEBIAN/control
@@ -1,14 +1,14 @@
 Package: bodhi-desktop-moksha
-Version: 0.1
+Version: 0.2
 Section: main
 Priority: optional
 Depends: bodhi-icons, bodhi-lightdm-theme, bodhi-slideshow, esudo, bodhi-skel, elaptopcheck, moksha, bodhi-profile-moksha, bodhi-plymouth-theme, bodhi-plymouth-text, evas-generic-loaders, bc, bash-completion, lupin-casper, policykit-desktop-privileges, terminology, packagekit, lxmenu-data, xdg-utils, bodhi-quickstart, python-dbus, apturl-elm, udisks, bodhi-dpkg-settings, places-moksha, moksha-pulsemixer
 Recommends: eepdater, epad, ephoto, thunar, ecomorph, ecomp
-Conflicts: bodhi-desktop, bodhi-desktop-e17
+Conflicts: bodhi-desktop, bodhi-desktop-e17, bodhi-profile-e17
 Architecture: all
 Maintainer: Doug Yanez
 Uploaders: Jeff Hoogland, Eric Brown
 #Vcs-Browser: https://github.com/Deepspeed/bodhi3packages
 Description: Bodhi Moksha Desktop
- A meta package that pulls in Bodhi related packages for Moksha
-
+ A Bodhi meta-package that pulls in Bodhi related packages for 
+ the Moksha Desktop


### PR DESCRIPTION
Prevents moksha desktop from failing to install due to not purging the e17 profile first.